### PR TITLE
Add geojson rendering

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,5 +4,8 @@
   },
   "extends": [
     "eslint-config-brigade"
-  ]
+  ],
+  "rules": {
+    "no-console": 0
+  }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,6 +6,7 @@
     "eslint-config-brigade"
   ],
   "rules": {
-    "no-console": 0
+    "no-console": 0,
+    "strict": [2, "global"]
   }
 }

--- a/.importjs.json
+++ b/.importjs.json
@@ -1,1 +1,7 @@
-{ "environments": ["node"] }
+{
+  "environments": ["node"],
+  "declarationKeyword": "const",
+  "aliases": {
+    "parseCsv": "csv-parse/lib/sync"
+  }
+}

--- a/Jakefile
+++ b/Jakefile
@@ -2,6 +2,7 @@
 
 /* global desc task file complete jake */
 const temp = require('temp');
+const execSync = require('child_process').execSync;
 
 temp.track(); // automatically cleanup temp dirs on exit
 
@@ -40,6 +41,47 @@ task('california', ['shapefiles', 'renderAll.js', 'build/tiles.json'], { async: 
   jake.exec([
     'node bin/renderAll.js /06',
   ], { printStdout: true, printStderr: true }, () => {
+    complete();
+  });
+});
+
+desc('package and upload GeoJSON files to S3');
+task('package-geoJSON', [], () => {
+  let tarBinary = 'tar';
+
+  execSync('tar --version', (err, stdout) => {
+    if (err !== undefined) {
+      console.log('Failed to call `tar` executable!');
+    }
+
+    if (stdout.indexOf('GNU tar') !== -1) {
+      // all's good in the hood!
+      return;
+    }
+
+    execSync('gtar --version', (err2) => {
+      if (err2 !== undefined) {
+        console.log('ERROR: You will need to install GNU tar for this upload to work.');
+        console.log('');
+        console.log('Run `brew install gnu-tar`.');
+      } else {
+        tarBinary = 'gtar';
+      }
+    });
+  });
+
+  jake.exec([
+    `bash -c "cd build/; find ocd-division -name geojson.json | \
+      ${tarBinary} -T- --transform='s/\\/geojson\\.json$/.json/' -czf tmp-geojson.tar.gz"`
+  ], { printStdout: true, printStderr: true }, () => {
+    console.log('Successfully output to build/tmp-geojson.tar.gz.');
+    console.log('');
+    console.log('You can now manually upload this to S3 with the AWS-CLI like:');
+    console.log('');
+    console.log('  aws s3 cp build/tmp-geojson.tar.gz s3://brigade-development/geojson-districts.tar.gz --acl=public-read');
+    console.log('');
+    console.log('(if you do not have aws-cli, you can install it with `pip install aws-cli`)');
+
     complete();
   });
 });

--- a/Jakefile
+++ b/Jakefile
@@ -7,8 +7,11 @@ temp.track(); // automatically cleanup temp dirs on exit
 
 desc('Render all maps');
 task('render', ['shapefiles', 'renderAll.js', 'build/tiles.json', 'renderGeoJSON.js'], () => {
+  const renderGeoJSON = require('./renderGeoJSON.js');
   const renderAll = require('./renderAll.js').renderAll;
   const filterTile = process.env.only;
+
+  renderGeoJSON(filterTile);
   renderAll(filterTile);
 });
 

--- a/Jakefile
+++ b/Jakefile
@@ -92,6 +92,7 @@ task('shapefiles', [
   'shapefiles/countries',
   'shapefiles/sldl',
   'shapefiles/sldu',
+  'shapefiles/county',
 ]);
 
 desc('clean up build residuals');

--- a/Jakefile
+++ b/Jakefile
@@ -1,10 +1,12 @@
+'use strict';
+
 /* global desc task file complete jake */
 const temp = require('temp');
 
 temp.track(); // automatically cleanup temp dirs on exit
 
 desc('Render all maps');
-task('render', ['shapefiles', 'renderAll.js', 'build/tiles.json'], () => {
+task('render', ['shapefiles', 'renderAll.js', 'build/tiles.json', 'renderGeoJSON.js'], () => {
   const renderAll = require('./renderAll.js').renderAll;
   const filterTile = process.env.only;
   renderAll(filterTile);
@@ -20,13 +22,15 @@ file('build/tiles.json', ['generateBuildConfig.js', 'config/maps.json'], { async
   });
 });
 
-file('config/114_congress/ocdid_mapping.csv', ['config/114_congress/generateOcdidMapping.js', 'data/fips.csv'], { async: true }, () => {
-  jake.exec([
-    'bash -c "node config/114_congress/generateOcdidMapping.js > config/114_congress/ocdid_mapping.csv"'
-  ], { printStdout: true, printStderr: true }, () => {
-    complete();
+file('config/114_congress/ocdid_mapping.csv',
+  ['config/114_congress/generateOcdidMapping.js', 'data/fips.csv'], { async: true }, () => {
+    jake.exec([
+      `bash -c "node config/114_congress/generateOcdidMapping.js >
+        config/114_congress/ocdid_mapping.csv"`
+    ], { printStdout: true, printStderr: true }, () => {
+      complete();
+    });
   });
-});
 
 desc('render california');
 task('california', ['shapefiles', 'renderAll.js', 'build/tiles.json'], { async: true }, () => {

--- a/README.md
+++ b/README.md
@@ -5,10 +5,6 @@ OCD Division ID (OCDID) Shapefiles
 
 ![example map - CA-12](https://raw.githubusercontent.com/tdooner/brigade-maps/master/example.png)
 
-# Adding a New Map
-To add a new map, follow the instructions [in this commit
-message](https://github.com/tdooner/brigade-maps/commit/15b485c1d8c4f2e8ff4fc1542961ab991bf60cbd)
-
 # Installation
 
 1. install node 5.x via nodenv or via some package manager
@@ -24,6 +20,30 @@ To see all available commands, run:
 export PATH=$(npm bin):$PATH
 jake -T
 ```
+
+Some common commands you might find useful:
+
+## Download all the Shapefiles
+```bash
+$(npm bin)/jake shapefiles
+```
+
+## Render everything
+```bash
+$(npm bin)/jake render
+```
+
+## Package GeoJSON for upload
+```bash
+$(npm bin)/jake package-geoJSON
+
+# then you will want to upload it with something like:
+aws s3 cp build/tmp-geojson.tar.gz s3://brigade-development/geojson-districts.tar.gz --acl=public-read
+```
+
+# Adding a New Map
+To add a new map, follow the instructions [in this commit
+message](https://github.com/tdooner/brigade-maps/commit/15b485c1d8c4f2e8ff4fc1542961ab991bf60cbd)
 
 # Uploading to Cloudinary
 

--- a/bin/renderAll.js
+++ b/bin/renderAll.js
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
-var renderAll = require('../renderAll.js').renderAll;
+'use strict';
 
-var filterTile = process.argv[2];
+const renderGeoJSON = require('../renderGeoJSON');
+const renderAll = require('../renderAll.js').renderAll;
+const filterTile = process.argv[2];
 
+renderGeoJSON(filterTile);
 renderAll(filterTile);

--- a/bin/renderAll.js
+++ b/bin/renderAll.js
@@ -1,9 +1,0 @@
-#!/usr/bin/env node
-'use strict';
-
-const renderGeoJSON = require('../renderGeoJSON');
-const renderAll = require('../renderAll.js').renderAll;
-const filterTile = process.argv[2];
-
-renderGeoJSON(filterTile);
-renderAll(filterTile);

--- a/bin/renderGeoJSON
+++ b/bin/renderGeoJSON
@@ -1,5 +1,0 @@
-#!/usr/bin/env node
-// vim: set ft=javascript
-'use strict';
-
-require('../makeGeoJSON.js')();

--- a/bin/renderGeoJSON
+++ b/bin/renderGeoJSON
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+// vim: set ft=javascript
+'use strict';
+
+require('../makeGeoJSON.js')();

--- a/generateBuildConfig.js
+++ b/generateBuildConfig.js
@@ -1,8 +1,11 @@
+'use strict';
+
 const fs = require('fs');
-const glob = require('glob');
+
 const mapnik = require('mapnik');
 const swig = require('swig');
 
+const buildConfig = require('./lib/buildConfig');
 const ocdidMappingProcessor = require('./lib/ocdidMappingProcessor');
 
 mapnik.register_default_input_plugins();
@@ -13,82 +16,49 @@ const HIGHLIGHT_COLORS = {
   local: '#3dc489'
 };
 
-// Globals
-// map configuration
-const config = JSON.parse(fs.readFileSync('config/maps.json'));
-
 // check if a feature matches any of the attributes in the skip list
-const shouldSkip = function(mapConfig, feature) {
-  if (mapConfig.skip) {
-    const datum = feature.attributes();
-
-    for (const attr of Object.keys(mapConfig.skip)) {
-      if (datum[attr] === mapConfig.skip[attr]) {
-        return true;
-      }
-    }
-  }
-  return false;
-};
-
 // output collection
 const tiles = [];
 
-Object.keys(config).forEach(function(map) {
-  const buildConfigDir = 'build/' + map;
+buildConfig().eachMap((mapName, mapConfig) => {
+  const buildConfigDir = 'build/' + mapName;
   console.log('Generating config ' + buildConfigDir);
   if (!fs.existsSync(buildConfigDir)) {
     fs.mkdirSync(buildConfigDir);
   }
 
-  ocdidMappingProcessor.generateOcdIdMaps(map, config[map]);
+  ocdidMappingProcessor.generateOcdIdMaps(mapName, mapConfig);
 
-  const shapefiles = glob.sync(config[map].shapefile);
-  const overrides = config[map].overrides || {};
+  mapConfig.eachFeature((feature, shapefile) => {
+    const datum = feature.attributes();
+    const renderAttributes = mapConfig.render_each.map((attr) => datum[attr]);
+    const tileName = renderAttributes.join('-');
 
-  for (const shapefile of shapefiles) {
-    const featureset = new mapnik.Datasource({ type: 'shape', file: shapefile }).featureset();
-    let feature;
-
-    // eslint-disable-next-line
-    while (feature = featureset.next()) {
-
-      if (shouldSkip(config[map], feature)) {
-        continue;
-      }
-
-      const datum = feature.attributes();
-      const renderAttributes = config[map].render_each.map((attr) => datum[attr]);
-
-      // skip rendering of tiles without an ocdid, since we won't represent
-      // them on brigade anywhere
-      const ocdid = ocdidMappingProcessor.getTileOCDID(renderAttributes, map, config[map]);
-      if (!ocdid) {
-        continue;
-      }
-
-      const extent = overrides[ocdid] || feature.extent();
-      const tileName = renderAttributes.join('-');
-
-      for (const level of config[map].levels) {
-        const xmlPath = buildConfigDir + '/' + tileName + '_' + level + '.xml';
-
-        datum.highlightColor = HIGHLIGHT_COLORS[level];
-        datum.shapefile = shapefile;
-
-        fs.writeFileSync(xmlPath,
-          swig.renderFile('config/' + map + '/stylesheet.xml.swig', datum)
-        );
-
-        tiles.push({
-          xmlPath: xmlPath,
-          ocdid: ocdid,
-          level: level,
-          extent: extent
-        });
-      }
+    // skip rendering of tiles without an ocdid, since we won't represent
+    // them on brigade anywhere
+    const ocdid = ocdidMappingProcessor.getTileOCDID(renderAttributes, mapName);
+    if (!ocdid) {
+      return;
     }
-  }
+
+    for (const level of mapConfig.levels) {
+      const xmlPath = buildConfigDir + '/' + tileName + '_' + level + '.xml';
+
+      datum.highlightColor = HIGHLIGHT_COLORS[level];
+      datum.shapefile = shapefile;
+
+      fs.writeFileSync(xmlPath,
+        swig.renderFile('config/' + mapName + '/stylesheet.xml.swig', datum)
+      );
+
+      tiles.push({
+        xmlPath: xmlPath,
+        ocdid: ocdid,
+        level: level,
+        extent: mapConfig.extent(feature, ocdid),
+      });
+    }
+  });
 });
 
 fs.writeFileSync('build/tiles.json', JSON.stringify(tiles));

--- a/lib/buildConfig.js
+++ b/lib/buildConfig.js
@@ -1,7 +1,9 @@
-"use strict";
+'use strict';
 
 const fs = require('fs');
 const path = require('path');
+
+const mapConfig = require('./mapConfig');
 
 /**
  * @param {Object} options
@@ -12,7 +14,19 @@ module.exports = function(options) {
   options = options || {};
   options.buildPath = options.buildPath || 'build/';
 
+  // Globals
+  // map configuration
+  const config = JSON.parse(fs.readFileSync('config/maps.json'));
+
   return {
+    eachMap(fn) {
+      Object.keys(config).forEach(mapName => fn(mapName, this.mapConfig(mapName)));
+    },
+
+    mapConfig(mapName) {
+      return mapConfig(config, mapName);
+    },
+
     moveToOCDID(tilePath, ocdid, level) {
       let buildPath = options.buildPath;
 

--- a/lib/buildConfig.js
+++ b/lib/buildConfig.js
@@ -1,0 +1,31 @@
+"use strict";
+
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * @param {Object} options
+ * @param {String} options.buildPath Root path to build tiles into
+ * @return {Object}
+ */
+module.exports = function(options) {
+  options = options || {};
+  options.buildPath = options.buildPath || 'build/';
+
+  return {
+    moveToOCDID(tilePath, ocdid, level) {
+      let buildPath = options.buildPath;
+
+      for (const part of ocdid.split('/')) {
+        buildPath = path.join(buildPath, part);
+        if (!fs.existsSync(buildPath)) {
+          fs.mkdirSync(buildPath);
+        }
+      }
+
+      const outPath = path.join(buildPath, level + path.extname(tilePath));
+      fs.renameSync(tilePath, outPath);
+      return outPath;
+    }
+  };
+};

--- a/lib/mapConfig.js
+++ b/lib/mapConfig.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const glob = require('glob');
+const mapnik = require('mapnik');
+
+const shouldSkip = function(mapConfig, feature) {
+  if (mapConfig.skip) {
+    const datum = feature.attributes();
+
+    for (const attr of Object.keys(mapConfig.skip)) {
+      if (datum[attr] === mapConfig.skip[attr]) {
+        return true;
+      }
+    }
+  }
+  return false;
+};
+
+module.exports = function(allMapConfigs, mapName) {
+  const config = allMapConfigs[mapName] || {};
+  const overrides = config.overrides || {};
+
+  return Object.assign(config, {
+    eachFeature(fn) {
+      const shapefiles = glob.sync(config.shapefile);
+
+      for (const shapefile of shapefiles) {
+        const featureset = new mapnik.Datasource({ type: 'shape', file: shapefile }).featureset();
+        let feature;
+
+        // eslint-disable-next-line
+        while (feature = featureset.next()) {
+          if (shouldSkip(config, feature)) {
+            continue;
+          }
+
+          fn(feature, shapefile);
+        }
+      }
+    },
+
+    extent(feature, ocdid) {
+      return overrides[ocdid] || feature.extent();
+    },
+  });
+};

--- a/lib/ocdidMappingProcessor.js
+++ b/lib/ocdidMappingProcessor.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const fs = require('fs');
 const path = require('path');
 

--- a/lib/ocdidMappingProcessor.js
+++ b/lib/ocdidMappingProcessor.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+const path = require('path');
+
+const parseCsv = require('csv-parse/lib/sync');
+
+const ocdidmaps = {};
+
+module.exports = {
+  // builds a hash from the ocdid_mapping file for quick ocdid lookups
+  generateOcdIdMaps(mapName, config) {
+    const mappingPath = path.join('config', mapName, 'ocdid_mapping.csv');
+    if (!fs.existsSync(mappingPath)) {
+      return null;
+    }
+
+    ocdidmaps[mapName] = {};
+
+    const rows = parseCsv(fs.readFileSync(mappingPath), { comment: '#' });
+    for (const row of rows) {
+      const key = this._ocdIdKey(row.slice(0, config.render_each.length));
+      ocdidmaps[mapName][key] = row[row.length - 1];
+    }
+  },
+
+  // looks up an ocdid from its 'render each' attributes
+  getTileOCDID(renderAttributes, mapName) {
+    return ocdidmaps[mapName][this._ocdIdKey(renderAttributes)];
+  },
+
+  // helper to transform the attributes from config['render_each'] into a hash key
+  _ocdIdKey(attributes) {
+    return attributes.join('.');
+  },
+};

--- a/lib/ocdidMappingProcessor.js
+++ b/lib/ocdidMappingProcessor.js
@@ -7,8 +7,10 @@ const ocdidmaps = {};
 
 module.exports = {
   // builds a hash from the ocdid_mapping file for quick ocdid lookups
-  generateOcdIdMaps(mapName, config) {
-    const mappingPath = path.join('config', mapName, 'ocdid_mapping.csv');
+  generateOcdIdMaps(mapName, config, basePath) {
+    basePath = basePath || 'config';
+
+    const mappingPath = path.join(basePath, mapName, 'ocdid_mapping.csv');
     if (!fs.existsSync(mappingPath)) {
       return null;
     }

--- a/lib/ocdidMappingProcessor.js
+++ b/lib/ocdidMappingProcessor.js
@@ -7,7 +7,7 @@ const ocdidmaps = {};
 
 module.exports = {
   // builds a hash from the ocdid_mapping file for quick ocdid lookups
-  generateOcdIdMaps(mapName, config, basePath) {
+  generateOcdIdMaps(mapName, mapConfig, basePath) {
     basePath = basePath || 'config';
 
     const mappingPath = path.join(basePath, mapName, 'ocdid_mapping.csv');
@@ -19,7 +19,7 @@ module.exports = {
 
     const rows = parseCsv(fs.readFileSync(mappingPath), { comment: '#' });
     for (const row of rows) {
-      const key = this._ocdIdKey(row.slice(0, config.render_each.length));
+      const key = this._ocdIdKey(row.slice(0, mapConfig.render_each.length));
       ocdidmaps[mapName][key] = row[row.length - 1];
     }
   },

--- a/lib/roundCoordinates.js
+++ b/lib/roundCoordinates.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const EPSILON = 0.0001;
+
+/**
+ * Rounds an arbitrarily-nested array of arrays of floating-point coordinates.
+ * Each coordinate is rounded if its value changes less than 0.0001.
+ * For example:
+ *   23.45678000001 -> 23.45678
+ *
+ * @param {Array} coords Arbitrarily nested array of coordinates.
+ * @return {Array} Same array structure, but rounded.
+ */
+const roundCoordinates = (coords) => {
+  if (Array.isArray(coords[0])) {
+    return coords.map(roundCoordinates);
+  } else {
+    const rounded = [];
+
+    for (const coordinate of coords) {
+      let roundable = false;
+
+      for (let i = 0; i < 15; i++) {
+        const multipliedCoordinate = coordinate * Math.pow(10, i);
+        if (Math.abs(Math.round(multipliedCoordinate) - multipliedCoordinate) < EPSILON) {
+          roundable = true;
+          rounded.push(Math.round(multipliedCoordinate) / Math.pow(10, i));
+          break;
+        }
+      }
+      if (!roundable) {
+        rounded.push(coordinate);
+      }
+    }
+
+    return rounded;
+  }
+};
+
+module.exports = roundCoordinates;

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   },
   "devDependencies": {
     "eslint": "^2.11.0",
-    "eslint-config-brigade": "^2.0.3"
+    "eslint-config-brigade": "^2.0.3",
+    "mocha": "^3.0.2"
   },
   "scripts": {
     "render": "jake render"

--- a/renderAll.js
+++ b/renderAll.js
@@ -1,7 +1,10 @@
-var mapnik = require('mapnik');
-var fs = require('fs');
+const buildConfig = require('./lib/buildConfig');
+
+const fs = require('fs');
 var path = require('path');
-var gm = require('gm');
+
+var mapnik = require('mapnik');
+
 var execSync = require('child_process').execSync;
 
 const TILESIZE = 512;
@@ -11,21 +14,6 @@ var merc = new mapnik.Projection('+init=epsg:3857');
 // register fonts and datasource plugins
 mapnik.register_default_fonts();
 mapnik.register_default_input_plugins();
-
-var moveToOCDID = function(tilePath, ocdid, level) {
-  var buildPath = 'build/';
-
-  for (part of ocdid.split('/')) {
-    buildPath = path.join(buildPath, part);
-    if (!fs.existsSync(buildPath)) {
-      fs.mkdirSync(buildPath);
-    }
-  }
-
-  var outPath = path.join(buildPath, level + path.extname(tilePath));
-  fs.renameSync(tilePath, outPath);
-  return outPath;
-};
 
 // Add some padding around a highlighted feature
 // extent coords are in the form [minx, miny, maxx, maxy]
@@ -60,7 +48,7 @@ var renderTile = function(tile) {
 
   map.renderFileSync(outPath);
 
-  outPath = moveToOCDID(outPath, tile.ocdid, tile.level);
+  outPath = buildConfig.moveToOCDID(outPath, tile.ocdid, tile.level);
 
   // apply 'water' background color
   execSync(

--- a/renderAll.js
+++ b/renderAll.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const buildConfig = require('./lib/buildConfig');
+const buildConfig = require('./lib/buildConfig')();
 
 const fs = require('fs');
 const path = require('path');
@@ -42,10 +42,10 @@ const renderTile = function(tile) {
 
   const map = new mapnik.Map(TILESIZE, TILESIZE);
   const xmlPath = tile.xmlPath;
-  const outPath = path.normalize(path.join(xmlPath, '..', path.basename(xmlPath, '.xml') + '.png'));
+  let outPath = path.normalize(path.join(xmlPath, '..', path.basename(xmlPath, '.xml') + '.png'));
   map.fromStringSync(fs.readFileSync(xmlPath).toString());
 
-  const extent = tile.extent;
+  let extent = tile.extent;
   extent = padExtent(extent);    // add padding around highlighted feature
   extent = merc.forward(extent); // convert to Web Mercator coords
   map.zoomToBox(extent);

--- a/renderAll.js
+++ b/renderAll.js
@@ -1,15 +1,17 @@
+'use strict';
+
 const buildConfig = require('./lib/buildConfig');
 
 const fs = require('fs');
-var path = require('path');
+const path = require('path');
 
-var mapnik = require('mapnik');
+const mapnik = require('mapnik');
 
-var execSync = require('child_process').execSync;
+const execSync = require('child_process').execSync;
 
 const TILESIZE = 512;
 
-var merc = new mapnik.Projection('+init=epsg:3857');
+const merc = new mapnik.Projection('+init=epsg:3857');
 
 // register fonts and datasource plugins
 mapnik.register_default_fonts();
@@ -18,9 +20,9 @@ mapnik.register_default_input_plugins();
 // Add some padding around a highlighted feature
 // extent coords are in the form [minx, miny, maxx, maxy]
 // or, roughly, (lower-left, top-right)
-var padExtent = function(extent) {
-  var xdiff = extent[2] - extent[0];
-  var ydiff = extent[3] - extent[1];
+const padExtent = function(extent) {
+  const xdiff = extent[2] - extent[0];
+  const ydiff = extent[3] - extent[1];
   return [
     extent[0] - xdiff * 0.1,
     extent[1] - ydiff * 0.1,
@@ -29,19 +31,21 @@ var padExtent = function(extent) {
   ];
 };
 
-var renderTile = function(tile) {
+const renderTile = function(tile) {
   // skip rendering tiles without an OCDID, as they won't be visible
   // in the product and this avoids rendering ~10K tiles
-  if (tile.ocdid == undefined) { return; }
+  if (tile.ocdid === undefined) {
+    return;
+  }
 
   console.log('Rendering ' + tile.xmlPath);
 
-  var map = new mapnik.Map(TILESIZE, TILESIZE);
-  var xmlPath = tile.xmlPath;
-  var outPath = path.normalize(path.join(xmlPath, '..', path.basename(xmlPath, '.xml') + '.png'));
+  const map = new mapnik.Map(TILESIZE, TILESIZE);
+  const xmlPath = tile.xmlPath;
+  const outPath = path.normalize(path.join(xmlPath, '..', path.basename(xmlPath, '.xml') + '.png'));
   map.fromStringSync(fs.readFileSync(xmlPath).toString());
 
-  var extent = tile.extent;
+  const extent = tile.extent;
   extent = padExtent(extent);    // add padding around highlighted feature
   extent = merc.forward(extent); // convert to Web Mercator coords
   map.zoomToBox(extent);
@@ -54,7 +58,7 @@ var renderTile = function(tile) {
   execSync(
     `gm convert ${outPath} -background '#d3ddff' -extent 0x0 ${outPath}`,
     function(error, stdout, stderr) {
-      if (error != undefined) {
+      if (error !== undefined) {
         console.log(`Failed to set background on ${outPath}`);
         console.log(error);
         console.log(stderr);
@@ -65,7 +69,7 @@ var renderTile = function(tile) {
 exports.renderTile = renderTile;
 
 exports.renderAll = function(filterTile) {
-  var tiles = JSON.parse(fs.readFileSync('build/tiles.json'));
+  const tiles = JSON.parse(fs.readFileSync('build/tiles.json'));
   tiles.forEach(function(tile) {
     if (filterTile && tile.xmlPath.indexOf(filterTile) === -1) {
       return;

--- a/renderGeoJSON.js
+++ b/renderGeoJSON.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const fs = require('fs');
+
+const simplify = require('simplify-geojson');
+
+const buildConfig = require('./lib/buildConfig')();
+const ocdidMappingProcessor = require('./lib/ocdidMappingProcessor');
+const roundCoordinates = require('./lib/roundCoordinates');
+
+module.exports = function() {
+  buildConfig.eachMap((mapName, mapConfig) => {
+    // load the OCDID translations for this map
+    ocdidMappingProcessor.generateOcdIdMaps(mapName, mapConfig);
+
+    mapConfig.eachFeature(feature => {
+      const datum = feature.attributes();
+      const renderAttributes = mapConfig.render_each.map((attr) => datum[attr]);
+      const ocdid = ocdidMappingProcessor.getTileOCDID(renderAttributes, mapName);
+
+      // Simplify the feature's shape, so the resulting GeoJSON is a usably
+      // small size.
+      //
+      // 0.02 is a hand-picked number -- it designates a tolerance in degrees
+      // (1 degree = ~69 mi) of which smaller lines should be simplified. This
+      // might require some tweaking.
+      // See: https://www.npmjs.com/package/simplify-geojson
+      const simplified = simplify(feature, 0.02).geometry;
+      simplified.coordinates = roundCoordinates(simplified.coordinates);
+
+      fs.writeFileSync('build/tmp.json', JSON.stringify(simplified));
+
+      buildConfig.moveToOCDID('build/tmp.json', ocdid, 'geojson');
+    });
+  });
+};

--- a/renderGeoJSON.js
+++ b/renderGeoJSON.js
@@ -10,6 +10,8 @@ const roundCoordinates = require('./lib/roundCoordinates');
 
 module.exports = function() {
   buildConfig.eachMap((mapName, mapConfig) => {
+    console.log('Generating GeoJSON files for ' + mapName);
+
     // load the OCDID translations for this map
     ocdidMappingProcessor.generateOcdIdMaps(mapName, mapConfig);
 
@@ -18,6 +20,10 @@ module.exports = function() {
       const renderAttributes = mapConfig.render_each.map((attr) => datum[attr]);
       const ocdid = ocdidMappingProcessor.getTileOCDID(renderAttributes, mapName);
 
+      if (!ocdid) {
+        return;
+      }
+
       // Simplify the feature's shape, so the resulting GeoJSON is a usably
       // small size.
       //
@@ -25,7 +31,8 @@ module.exports = function() {
       // (1 degree = ~69 mi) of which smaller lines should be simplified. This
       // might require some tweaking.
       // See: https://www.npmjs.com/package/simplify-geojson
-      const simplified = simplify(feature, 0.02).geometry;
+      const featureAsGeoJSON = JSON.parse(feature.toJSON());
+      const simplified = simplify(featureAsGeoJSON, 0.02).geometry;
       simplified.coordinates = roundCoordinates(simplified.coordinates);
 
       fs.writeFileSync('build/tmp.json', JSON.stringify(simplified));

--- a/test/buildConfigTest.js
+++ b/test/buildConfigTest.js
@@ -1,0 +1,31 @@
+/* global describe it beforeEach */
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const temp = require('temp');
+
+const buildConfig = require('../lib/buildConfig');
+
+describe('buildConfig', function() {
+  beforeEach(() => {
+    temp.track();
+
+    this.tempdir = temp.mkdirSync('maps-buildConfig-moveToOCDID');
+    this.buildConfig = buildConfig({ buildPath: this.tempdir });
+  });
+
+  describe('moveToOCDID', () => {
+    it('moves a file correctly', () => {
+      const testTilePath = path.join(this.tempdir, 'testTile.txt');
+      const expectedDestination =
+        path.join(this.tempdir, 'ocd-division', 'foo:1', 'bar:1', 'federal.txt');
+
+      fs.writeFileSync(testTilePath, 'foo');
+
+      this.buildConfig.moveToOCDID(testTilePath, 'ocd-division/foo:1/bar:1', 'federal');
+
+      assert.equal(fs.readFileSync(expectedDestination), 'foo');
+    });
+  });
+});

--- a/test/fixtures/test_ocdid_mapping/ocdid_mapping.csv
+++ b/test/fixtures/test_ocdid_mapping/ocdid_mapping.csv
@@ -1,0 +1,3 @@
+1,1,ocd-division/foo:1/bar:1
+1,2,ocd-division/foo:1/bar:2
+2,2,ocd-division/foo:2/bar:2

--- a/test/ocdidMappingProcessorTest.js
+++ b/test/ocdidMappingProcessorTest.js
@@ -1,0 +1,21 @@
+/* global describe it */
+const assert = require('assert');
+
+const ocdidMappingProcessor = require('../lib/ocdidMappingProcessor');
+
+describe('ocdidMappingProcessor', function() {
+  it('maps correctly', () => {
+    const config = {
+      render_each: ['PROP_ONE', 'PROP_TWO'],
+    };
+
+    ocdidMappingProcessor.generateOcdIdMaps('test_ocdid_mapping', config, 'test/fixtures');
+
+    const calculatedOCDID = ocdidMappingProcessor.getTileOCDID(
+      ['1', '1'], // render attributes (PROP_ONE and PROP_TWO)
+      'test_ocdid_mapping'
+    );
+
+    assert.equal('ocd-division/foo:1/bar:1', calculatedOCDID);
+  });
+});

--- a/test/ocdidMappingProcessorTest.js
+++ b/test/ocdidMappingProcessorTest.js
@@ -1,21 +1,34 @@
-/* global describe it */
+/* global describe it beforeEach */
+'use strict';
+
 const assert = require('assert');
 
 const ocdidMappingProcessor = require('../lib/ocdidMappingProcessor');
 
 describe('ocdidMappingProcessor', function() {
-  it('maps correctly', () => {
+  beforeEach(() => {
     const config = {
       render_each: ['PROP_ONE', 'PROP_TWO'],
     };
 
     ocdidMappingProcessor.generateOcdIdMaps('test_ocdid_mapping', config, 'test/fixtures');
+  });
 
+  it('maps correctly', () => {
     const calculatedOCDID = ocdidMappingProcessor.getTileOCDID(
       ['1', '1'], // render attributes (PROP_ONE and PROP_TWO)
       'test_ocdid_mapping'
     );
 
     assert.equal('ocd-division/foo:1/bar:1', calculatedOCDID);
+  });
+
+  it('handles more than just the first row', () => {
+    const calculatedOCDID = ocdidMappingProcessor.getTileOCDID(
+      ['1', '2'], // render attributes (PROP_ONE and PROP_TWO)
+      'test_ocdid_mapping'
+    );
+
+    assert.equal('ocd-division/foo:1/bar:2', calculatedOCDID);
   });
 });

--- a/test/roundCoordinatesTets.js
+++ b/test/roundCoordinatesTets.js
@@ -1,0 +1,20 @@
+/* global describe it */
+'use strict';
+
+const assert = require('assert');
+
+const roundCoordinates = require('../lib/roundCoordinates');
+
+describe('roundCoordinates', () => {
+  it('rounds an array of coordinates correctly', () => {
+    assert.deepEqual(
+      roundCoordinates(
+        // the array nesting structure is arbitrary
+        [[[1.002000001], // rounds to 1.0002
+          [[1.020001, 1.020002]] // the first one rounds, but not the second
+        ]]),
+
+      [[[1.002], [[1.02, 1.020002]]]]
+    );
+  });
+});


### PR DESCRIPTION
This branch modularizes some aspects of the configuration / building / rendering pipeline so they can be shared by a new top-level script `renderGeoJSON.js` which iterates over the same shapefiles'  `render_each` properties (as specified in the map configs in `config/map.js`) to also dump a GeoJSON file as part of the render.

These GeoJSON files end up in, for example, `build/ocd-division/state:ca/cd:1/geojson.json`. Then, with the `package-geoJSON` jake task, these are tar'd up into an archive that can be published to S3 and consumed by a team of developers hungry for mapping data in their application!
