### PR TITLE
Fix district map counties including water

### DIFF
--- a/config/county/stylesheet.xml.swig
+++ b/config/county/stylesheet.xml.swig
@@ -34,11 +34,7 @@
     </Datasource>
   </Layer>
 
-  <!--
-    src-atop: only draw where we intersect with the existing render. This fixes
-    district lines that extend out into the sea and become unrecognizable.
-  -->
-  <Style name="county" comp-op="src-atop">
+  <Style name="county">
     <Rule>
       <PolygonSymbolizer fill="#ebebeb" />
     </Rule>

--- a/config/maps.json
+++ b/config/maps.json
@@ -52,7 +52,7 @@
     }
   },
   "county": {
-    "shapefile": "shapefiles/county/*.shp",
+    "shapefile": "shapefiles/county_land/*.shp",
     "render_each": ["GEOID"],
     "levels": ["local"],
     "overrides": {


### PR DESCRIPTION
The county shapefiles we use to generate the GeoJSON include water.

This was a problem we initially solved at render-time through clever use
of the "src-atop" rendering option. This worked pretty well at the time,
but now that we need to also output GeoJSON shapes for these counties
with the same geometry, we'll need to do this earlier in the rendering
pipeline.

This adds a couple "computed" shapefiles that are output by running
`mapshaper` commands to clip / filter existing shapes.

[Fixes API-1496] - Fix district map counties including water
